### PR TITLE
fix(types): set links as optional property

### DIFF
--- a/src/types/json-api.ts
+++ b/src/types/json-api.ts
@@ -6,7 +6,7 @@ export interface JsonApi {
 }
 
 export interface JsonApiDataResponse extends JsonApi {
-  links: JsonApiLinks
+  links?: JsonApiLinks
   data: JsonApiResource | JsonApiResource[]
   included?: JsonApiResource[]
   meta?: {


### PR DESCRIPTION
All responses doesn't return a links array and that was creating an issue with .transform()